### PR TITLE
Added ability to set a custom field separator.

### DIFF
--- a/lib/anki/deck.rb
+++ b/lib/anki/deck.rb
@@ -1,11 +1,12 @@
 # coding: utf-8
 module Anki
   class Deck
-    attr_accessor :card_headers,:card_data
+    attr_accessor :card_headers,:card_data,:field_separator
 
     def initialize(options = {})
       @card_headers = options.delete(:card_headers)
       @card_data = options.delete(:card_data)
+      @field_separator = options.delete(:field_separator) || ";"
     end
 
     def generate_deck(options = {})
@@ -24,7 +25,7 @@ module Anki
     private
 
     def card_header_to_string()
-      "#" + self.card_headers.join(";") + "\n"
+      "#" + self.card_headers.join(@field_separator) + "\n"
     end
 
     def card_data_to_string(card)
@@ -32,7 +33,7 @@ module Anki
 
       card.default = ""
 
-      self.card_headers.map{ |header| card[header] }.join(";")
+      self.card_headers.map{ |header| card[header] }.join(@field_separator)
     end
 
     def create_file(str, file)

--- a/spec/anki/deck_spec.rb
+++ b/spec/anki/deck_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe Anki::Deck do
       expect(subject.generate_deck).to eq("#front;back\na;b\nc;d")
     end
 
+    it "returns a string with the card_headers comment, card_data values separated by a custom delimiter, and new cards by line breaks" do
+      subject.card_headers = headers
+      subject.card_data = cards
+      subject.field_separator = "|"
+      expect(subject.generate_deck).to eq("#front|back\na|b\nc|d")
+    end
+
     it "saves to a file if the file option is passed" do
       subject.card_headers = headers
       subject.card_data = cards


### PR DESCRIPTION
A semicolon is used if no custom separator is specified.
